### PR TITLE
Minor fix-ups for Darwin

### DIFF
--- a/src/poller/iwn_poller.c
+++ b/src/poller/iwn_poller.c
@@ -680,7 +680,13 @@ void iwn_poller_poke(struct iwn_poller *p) {
   {
     struct kevent ev[] = {
       { p->fd, EVFILT_USER, EV_ADD | EV_ONESHOT },
+#if defined(NOTE_TRIGGER)
       { p->fd, EVFILT_USER, 0, NOTE_TRIGGER     }
+#elif defined(EV_TRIGGER)
+      { p->fd, EVFILT_USER, EV_TRIGGER, 0       }
+#else
+#error "Either NOTE_TRIGGER or EV_TRIGGER is required."
+#endif
     };
     if (kevent(p->fd, ev, sizeof(ev) / sizeof(ev[0]), 0, 0, 0) == -1) {
       iwlog_ecode_error3(iwrc_set_errno(IW_ERROR_ERRNO, errno));

--- a/src/poller/iwn_proc.c
+++ b/src/poller/iwn_proc.c
@@ -22,6 +22,13 @@
 #include <sys/prctl.h>
 #endif
 
+#ifdef __APPLE__
+#include <crt_externs.h>
+#define environ (*_NSGetEnviron())
+#else
+  extern char **environ;
+#endif
+
 #define FDS_STDOUT 0
 #define FDS_STDERR 1
 #define FDS_STDIN  2
@@ -677,7 +684,6 @@ iwrc iwn_proc_spawn(const struct iwn_proc_spec *spec, pid_t *out_pid) {
     }
 
     if (spec->env) {
-      extern char **environ;
       environ = proc->envp;
     }
 


### PR DESCRIPTION
These do not fix existing issues with tests, but at least fixes the build on some older macOS.
(10.4–10.5 will need another fallback for kevent, there is no `EV_TRIGGER` there too.)